### PR TITLE
bugfix: should be Math.floor on pill estimates

### DIFF
--- a/src/StationPills/StationPills.js
+++ b/src/StationPills/StationPills.js
@@ -35,13 +35,23 @@ class StationPills extends Component {
       return <Icon>train</Icon>;
     } else if(this.state.desc === 'Arrived' || this.state.desc === 'Boarding') {
       return <Icon className="rot90">publish</Icon>;
-    } else {
-      var time = Math.ceil(this.state.time / 60);
-      if (time < 10) {
-        time = "0" + time;
-      }
-      return ':' + time;
     }
+
+    // NOTE: subtracting 30s because it looks like marta adds it to seconds
+    // (pills use the seconds, station/train views use the "1 min" text,
+    // and apparently they differ in their definition? somehow. thanks marta)
+    var time = Math.floor((this.state.time - 30) / 60);
+
+    // in my observations, "Arriving" appears at 90s mark (1min + 30s!)
+    // so this shouldn't happen, but just in case
+    if (time <= 0) {
+      return <Icon>train</Icon>;
+    }
+
+    if (time < 10) {
+      time = "0" + time;
+    }
+    return ':' + time;
   }
 
   render() {


### PR DESCRIPTION
This one was reported by @jamesgecko, but I've experienced it myself. Turns out I was doing `Math.ceil` on the minute estimates that show up on the station pills. This leads to surprising results when you click into a station, if you saw 2min or 3min in the pill, but "arriving" when clicking in suddenly. In my experience, 90s is the threshold for a train entering "Arriving." So we want to show 1min if you look within that 1-2min window, and we want to show 2min if you look within the 2-3min window.

- TIL: marta adds 30s to `waiting_seconds`. If you watch `waiting_time`, it corresponds with `(waiting_seconds - 30)`. Who knows why. This arcane knowledge is now baked in! \o/
- I don't think it's possible for the zero case to occur, but I put in a catch for it anyways. If a zero somehow gets in there, we'll swap in "arriving" instead.
- I eyeballed this with the train data right now and we have achieved synchronicity, when clicking between views!