### PR TITLE
Remove deprecated `componentWillReceiveProps` method

### DIFF
--- a/src/StationListItem/StationListItem.js
+++ b/src/StationListItem/StationListItem.js
@@ -8,28 +8,45 @@ import Stations from '../marta/stations';
 class StationListItem {
   static render(stationName, arrivalData) {
     let link = "/station/" + stationName.replace(/ /g, '-');
+    const arrivals = this.arrivalsByDirection(arrivalData, stationName);
+
     return (
       <ListItem divider key={stationName} component={Link} to={link}>
         <ListItemText className="station-list-title" primary={stationName.replace(/ station$/i, '')} />
-        {this.renderPills(arrivalData)}
+        {this.renderPills(arrivals)}
       </ListItem>
     );
   }
 
   static renderPills(arrivalData) {
     if (!arrivalData) return StationPills.blankPills();
-    var res = [];
-    for(var i = 0; i < 4; i++) {
-      var dir = Stations.DIRS[i];
-      var d = arrivalData[dir];
-      if (!d) continue;
-      res.push(
-        <StationPills key={dir + d.line}
-          dir={dir} desc={d.desc} time={d.time}
-          line={d.line} />
-      );
+
+    return arrivalData.map((train) =>
+      <StationPills key={train.id + train.stationName}
+        dir={train.direction}
+        desc={train.desc}
+        time={train.time}
+        line={train.line} />
+    );
+  }
+
+  /**
+   * Tranform arrivals into an array, sorted by the direction, augmented with direction and station name
+   */
+  static arrivalsByDirection(arrivalData, stationName) {
+    if (arrivalData) {
+      const orderedDirections = Stations.DIRS;
+      const orderedArrivals = [];
+      orderedDirections.forEach((d) => {
+        if (arrivalData[d]) {
+          arrivalData[d].direction = d;
+          arrivalData[d].stationName = stationName;
+          orderedArrivals.push(arrivalData[d]);
+        }
+      });
+
+      return orderedArrivals;
     }
-    return res;
   }
 }
 

--- a/src/StationPills/StationPills.js
+++ b/src/StationPills/StationPills.js
@@ -10,37 +10,17 @@ class StationPills extends Component {
     return BLANK_CHIP;
   }
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      dir: props.dir,
-      line: props.line,
-      desc: props.desc,
-      time: props.time
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    var updates = {};
-    for(var i in nextProps) {
-      if(this.state[i] !== nextProps[i]) {
-        updates[i] = nextProps[i];
-      }
-    }
-    this.setState(updates);
-  }
-
   timeDisplay() {
-    if (this.state.desc.indexOf('Arriving') === 0) {
+    if (this.props.desc.indexOf('Arriving') === 0) {
       return <Icon>train</Icon>;
-    } else if(this.state.desc === 'Arrived' || this.state.desc === 'Boarding') {
+    } else if(this.props.desc === 'Arrived' || this.props.desc === 'Boarding') {
       return <Icon className="rot90">publish</Icon>;
     }
 
     // NOTE: subtracting 30s because it looks like marta adds it to seconds
     // (pills use the seconds, station/train views use the "1 min" text,
     // and apparently they differ in their definition? somehow. thanks marta)
-    var time = Math.floor((this.state.time - 30) / 60);
+    var time = Math.floor((this.props.time - 30) / 60);
 
     // in my observations, "Arriving" appears at 90s mark (1min + 30s!)
     // so this shouldn't happen, but just in case
@@ -55,8 +35,8 @@ class StationPills extends Component {
   }
 
   render() {
-    var className = this.state.line + 'Line Pill';
-    return <Chip classes={{root: className}} avatar={<Avatar>{this.state.dir}</Avatar>} label={this.timeDisplay()} />;
+    var className = this.props.line + 'Line Pill';
+    return <Chip classes={{root: className}} avatar={<Avatar>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
   }
 }
 


### PR DESCRIPTION

<img width="545" alt="marta io 2019-09-10 20-42-23" src="https://user-images.githubusercontent.com/5190305/64659834-b81abe80-d40b-11e9-8f24-e21718e82005.png">

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

Long story short, it's yelling at us to do it a different way.

- Change the way the components are rendered in the parent,
so that the components are automatically updated without a manual
`setState`

- Change the StationPills component to use props directly, since it's
not mutating them and doesn't need to hold a temp state anymore

(I was trying to get a good gif of the UI updating but it's late the trains are slow. I'll get one tomorrow).