### PR TITLE
Dark Mode: remove setting, adhere to prefers-color-scheme setting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,8 +6,8 @@ import React, { Component } from "react";
 import Grid from "@material-ui/core/Grid";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 // CSS
-import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
-import AppThemeOptions from './theme/theme'
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import ThemeManager from './theme/manager';
 import { CssBaseline } from '@material-ui/core';
 
 
@@ -18,26 +18,14 @@ class App extends Component {
     this.state = { darkTheme: Settings.get('darkTheme') };
   }
 
-  theme() {
-    return this.state.darkTheme ? 'dark' : 'light';
-  }
-
   render() {
-    const toggleTheme = () => {
-      Settings.toggle('darkTheme');
-      this.setState({ darkTheme: Settings.get('darkTheme') });
-    }
-
-    const theme = this.theme();
-    const themeOpts = AppThemeOptions[theme];
-
     return (
       <Router>
-        <MuiThemeProvider theme={createMuiTheme(themeOpts)}>
+        <MuiThemeProvider theme={ThemeManager.cachedTheme()}>
           <CssBaseline />
           <Grid container justify="center" spacing={0}>
             <Grid item xs={12} xl={4}>
-              <Route exact path="/" render={() => <StationList theme={theme} toggleTheme={toggleTheme} />} />
+              <Route exact path="/" component={StationList} />
               <Route path="/station/:station" component={StationView} />
               <Route path="/train/:train_id" component={TrainView} />
             </Grid>

--- a/src/StationList/StationList.js
+++ b/src/StationList/StationList.js
@@ -1,7 +1,6 @@
 // npm packages
 import React, { Component } from 'react';
 // Material UI
-import { Switch } from '@material-ui/core';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -14,16 +13,15 @@ import Button from '@material-ui/core/Button';
 import StarredStations from '../StarredStations/StarredStations';
 import NearbyStations from '../NearbyStations/NearbyStations';
 import AllStations from '../AllStations/AllStations';
+import ThemeManager from '../theme/manager';
 
 class StationList extends Component {
 
   themeAwareClass(className) {
-    return `${className} ${className}--${this.props.theme}`;
+    return `${className} ${className}--${ThemeManager.current()}`;
   }
 
   render() {
-    const { theme, toggleTheme } = this.props // passing theme and function for toggling different themes
-
     var list = [];
     list.push(<StarredStations key="starredStations" />);
     list.push(<NearbyStations key="nearbyStations" />);
@@ -41,7 +39,6 @@ class StationList extends Component {
         </AppBar>
         <List className={this.themeAwareClass('StationListHolder')}>{list}</List>
         <Paper className="bottom-links" elevation={0} style={{ justifyContent: 'space-around', display: 'flex', padding: '16px' }}>
-          <div className={this.themeAwareClass('StationListTheme-text')}><Switch checked={theme === 'dark'} onChange={toggleTheme} />Dark Theme</div>
           <Button variant="fab" mini={true} onClick={() => window.location = "https://twitter.com/jakswa"}>
             <Avatar src="https://s.gravatar.com/avatar/721d6b5c0b5345637b76ea17318a447c?s=80&r=g" />
           </Button>

--- a/src/theme/manager.js
+++ b/src/theme/manager.js
@@ -1,0 +1,32 @@
+import AppThemeOptions from './theme';
+import { createMuiTheme } from "@material-ui/core/styles";
+
+class ThemeManager {
+  static darkSubscribe() {
+    if (this.prefersDark !== undefined) return;
+
+    let query = window.matchMedia('(prefers-color-scheme: dark)');
+    this.prefersDark = query.matches;
+    query.onchange = () => {
+      this.prefersDark = query.matches;
+    };
+  }
+
+  static current() {
+    return this.prefersDark ? 'dark' : 'light';
+  }
+
+  static cachedTheme() {
+    this.darkSubscribe();
+    let currentTheme = this.current();
+
+    if (this.themeSetting !== currentTheme) {
+      this.themeSetting = currentTheme;
+      const themeOpts = AppThemeOptions[currentTheme];
+      this.builtTheme = createMuiTheme(themeOpts);
+    }
+    return this.builtTheme;
+  }
+}
+
+export default ThemeManager


### PR DESCRIPTION
- :zap: If literally anyone pipes up asking to keep a manually-set flag in the UI, then I'll see about keeping a way to 'force' the theme one way or another. The switch was a good first pass, but I've grown to dislike it.
- the 2nd iteration of "dark mode" is inspired by [this top-of-HN blog post](https://tombrow.com/dark-mode-website-css), and would just use the device setting! Let's not store anything or add UI to manage it? What a world!
- tested this on android and it works when you toggle the dark/light
setting on your device
- also tested that i could get firefox on linux to prefer dark (unsure
    what's up my with chrome on linux...)

We've got pretty good support here from the browsers we care about:
![image](https://user-images.githubusercontent.com/137793/66440274-7b3cea00-ea00-11e9-9a11-2dc84200687e.png)

