### PR TITLE
update 1.X -> 4.X, demo the styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "^1.5.1",
+    "@material-ui/core": "^4.5.1",
+    "@material-ui/styles": "^4.5.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-router-dom": "^5.1.2",

--- a/public/index.html
+++ b/public/index.html
@@ -67,13 +67,6 @@
         margin-bottom: 5px;
       }
 
-      .Pill span {
-        font-weight: 700;
-        font-size: 1rem;
-        padding-left: 6px;
-        box-sizing: content-box;
-      }
-
       .Pill span.material-icons {
         font-size: 1.1rem;
       }
@@ -84,24 +77,31 @@
         top: -2px;
       }
 
+      .ContainerStationPills :not(.BlankChip) .MuiChip-label {
+        font-family: monospace;
+        font-weight: 700;
+        font-size: 1.3rem;
+      }
+
+      .Badge.MuiChip-avatar {
+        color: #fff;
+        font-size: 1.1rem;
+      }
+
       .GOLDLine .Badge {
         background-color: #ffa700;
-        color: #fff
       }
 
       .REDLine .Badge {
         background-color: #ff5100;
-        color: #fff
       }
 
       .GREENLine .Badge {
         background-color: green;
-        color: #fff
       }
 
       .BLUELine .Badge {
         background-color: #30a7fa;
-        color: #fff
       }
 
       #update-notify .update-notify {

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,12 @@
         font-family: Roboto,Open Sans,Droid,Ubuntu,sans-serif
       }
 
+      /* ughhh they changed the list item padding to 8px on latest MUI */
+      #root .MuiListItem-root.MuiListItem-button {
+        padding-top: 12px;
+        padding-bottom: 12px;
+      }
+
       .StationView h6 {
         text-transform: capitalize
       }
@@ -68,24 +74,28 @@
       }
 
       .Pill span.material-icons {
-        font-size: 1.1rem;
+        font-size: 1.2rem;
       }
 
       .rot90 {
         transform: rotate(90deg);
         position: relative;
-        top: -2px;
+        top: -3px;
       }
 
       .ContainerStationPills :not(.BlankChip) .MuiChip-label {
         font-family: monospace;
         font-weight: 700;
-        font-size: 1.3rem;
+        font-size: 1.4rem;
       }
 
-      .Badge.MuiChip-avatar {
+      .MuiChip-root .Badge.MuiChip-avatar {
         color: #fff;
-        font-size: 1.1rem;
+        font-size: 1.3rem;
+        width: 32px;
+        height: 32px;
+        margin-top: 0px;
+        margin-left: 0px;
       }
 
       .GOLDLine .Badge {
@@ -153,6 +163,13 @@
 
       .dark .Pill span {
         opacity: 0.75;
+      }
+
+      .Pill span {
+        font-weight: 700;
+        padding-left: 8px;
+        box-sizing: content-box;
+        text-align: center;
       }
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
         font-family: Roboto,Open Sans,Droid,Ubuntu,sans-serif
       }
 
-      .StationView h2 {
+      .StationView h6 {
         text-transform: capitalize
       }
 
@@ -64,7 +64,6 @@
       .Pill {
         margin-left: 5px;
         font-weight: 500;
-        font-family: monospace !important;
         margin-bottom: 5px;
       }
 

--- a/src/StationList/StationList.js
+++ b/src/StationList/StationList.js
@@ -8,7 +8,7 @@ import Paper from '@material-ui/core/Paper';
 import List from '@material-ui/core/List';
 import Avatar from '@material-ui/core/Avatar';
 import Icon from '@material-ui/core/Icon';
-import Button from '@material-ui/core/Button';
+import Fab from '@material-ui/core/Fab';
 // Components
 import StarredStations from '../StarredStations/StarredStations';
 import NearbyStations from '../NearbyStations/NearbyStations';
@@ -26,22 +26,22 @@ class StationList extends Component {
       <div className="StationList">
         <AppBar position="static" color="primary" elevation={0} >
           <Toolbar>
-            <Typography variant="title" color="inherit">
+            <Typography variant="h6" color="inherit">
               Stations
             </Typography>
           </Toolbar>
         </AppBar>
         <List className="StationListHolder">{list}</List>
         <Paper className="bottom-links" elevation={0} style={{ justifyContent: 'space-around', display: 'flex', padding: '16px' }}>
-          <Button variant="fab" mini={true} onClick={() => window.location = "https://twitter.com/jakswa"}>
+          <Fab size="small" onClick={() => window.location = "https://twitter.com/jakswa"}>
             <Avatar src="https://s.gravatar.com/avatar/721d6b5c0b5345637b76ea17318a447c?s=80&r=g" />
-          </Button>
-          <Button style={{ marginLeft: '16px' }} mini={true} variant="fab" color="secondary" onClick={() => window.location = "https://github.com/jakswa/marta_ui"}>
+          </Fab>
+          <Fab size="small" style={{ marginLeft: '16px' }} color="secondary" onClick={() => window.location = "https://github.com/jakswa/marta_ui"}>
             <Icon>code</Icon>
-          </Button>
-          <Button style={{ marginLeft: '16px' }} mini={true} variant="fab" color="secondary" onClick={() => window.location = "https://gitter.im/marta_ui/Lobby"}>
+          </Fab>
+          <Fab size="small" style={{ marginLeft: '16px' }} color="secondary" onClick={() => window.location = "https://gitter.im/marta_ui/Lobby"}>
             <Icon>message</Icon>
-          </Button>
+          </Fab>
         </Paper>
       </div>
     );

--- a/src/StationListItem/StationListItem.js
+++ b/src/StationListItem/StationListItem.js
@@ -4,6 +4,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import StationPills from '../StationPills/StationPills';
 import Stations from '../marta/stations';
+import Box from '@material-ui/core/Box'
 
 class StationListItem {
   static render(stationName, arrivalData) {
@@ -13,7 +14,7 @@ class StationListItem {
     return (
       <ListItem divider button key={stationName} component={Link} to={link}>
         <ListItemText className="station-list-title" primary={stationName.replace(/ station$/i, '')} />
-        <div className="ContainerStationPills">{this.renderPills(arrivals)}</div>
+        <Box className="ContainerStationPills">{this.renderPills(arrivals)}</Box>
       </ListItem>
     );
   }

--- a/src/StationListItem/StationListItem.js
+++ b/src/StationListItem/StationListItem.js
@@ -11,7 +11,7 @@ class StationListItem {
     const arrivals = this.arrivalsByDirection(arrivalData, stationName);
 
     return (
-      <ListItem divider key={stationName} component={Link} to={link}>
+      <ListItem divider button key={stationName} component={Link} to={link}>
         <ListItemText className="station-list-title" primary={stationName.replace(/ station$/i, '')} />
         <div className="ContainerStationPills">{this.renderPills(arrivals)}</div>
       </ListItem>

--- a/src/StationPills/StationPills.js
+++ b/src/StationPills/StationPills.js
@@ -1,9 +1,14 @@
 import React, { Component } from 'react';
+import { styled } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import Avatar from '@material-ui/core/Avatar';
 import Icon from '@material-ui/core/Icon';
 
 const BLANK_CHIP = <Chip className="BlankChip" style={{opacity: 0.5}} label="NO DATA" />;
+
+const MyChip = styled(Chip)({
+  fontFamily: 'monospace'
+});
 
 class StationPills extends Component {
   static blankPills() {
@@ -36,7 +41,7 @@ class StationPills extends Component {
 
   render() {
     var className = this.props.line + 'Line Pill';
-    return <Chip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
+    return <MyChip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
   }
 }
 

--- a/src/StationPills/StationPills.js
+++ b/src/StationPills/StationPills.js
@@ -1,14 +1,9 @@
 import React, { Component } from 'react';
-import { styled } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import Avatar from '@material-ui/core/Avatar';
 import Icon from '@material-ui/core/Icon';
 
 const BLANK_CHIP = <Chip className="BlankChip" style={{opacity: 0.5}} label="NO DATA" />;
-
-const MyChip = styled(Chip)({
-  fontFamily: 'monospace'
-});
 
 class StationPills extends Component {
   static blankPills() {
@@ -41,7 +36,7 @@ class StationPills extends Component {
 
   render() {
     var className = this.props.line + 'Line Pill';
-    return <MyChip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
+    return <Chip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
   }
 }
 

--- a/src/StationView/StationView.js
+++ b/src/StationView/StationView.js
@@ -12,6 +12,7 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import Box from '@material-ui/core/Box';
 
 class StationView extends Component {
   constructor(props) {
@@ -88,7 +89,7 @@ class StationView extends Component {
       res.push(
         <ListItem button divider key={arrival.TRAIN_ID} component={Link} to={"/train/" + arrival.TRAIN_ID}>
           <Chip classes={{ root: className }} avatar={<Avatar className="Badge">{arrival.DIRECTION}</Avatar>} label={arrival.DESTINATION} />
-          <ListItemText primary={arrival.WAITING_TIME} />
+          <Box mx={2}><ListItemText primary={arrival.WAITING_TIME} /></Box>
         </ListItem>
       );
     }

--- a/src/StationView/StationView.js
+++ b/src/StationView/StationView.js
@@ -62,7 +62,7 @@ class StationView extends Component {
         <AppBar position="static" color='primary' elevation={0}>
           <Toolbar>
             <IconButton onClick={this.goBack} color="default"><Icon style={{color: 'white'}}>arrow_back</Icon></IconButton>
-            <Typography variant="title" color="inherit">
+            <Typography variant="h6" color="inherit">
               {this.state.stationName}
             </Typography>
             <IconButton onClick={this.toggleStar.bind(this)}><Icon style={{color: 'white'}}>{this.starIcon()}</Icon></IconButton>
@@ -86,7 +86,7 @@ class StationView extends Component {
       var arrival = this.state.arrivals[i];
       var className = arrival.LINE + "Line";
       res.push(
-        <ListItem divider key={arrival.TRAIN_ID} component={Link} to={"/train/" + arrival.TRAIN_ID}>
+        <ListItem button divider key={arrival.TRAIN_ID} component={Link} to={"/train/" + arrival.TRAIN_ID}>
           <Chip classes={{ root: className }} avatar={<Avatar className="Badge">{arrival.DIRECTION}</Avatar>} label={arrival.DESTINATION} />
           <ListItemText primary={arrival.WAITING_TIME} />
         </ListItem>

--- a/src/TrainView/TrainView.js
+++ b/src/TrainView/TrainView.js
@@ -10,6 +10,7 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import Box from '@material-ui/core/Box';
 
 class StationView extends Component {
   constructor(props) {
@@ -74,7 +75,7 @@ class StationView extends Component {
       res.push(
         <ListItem button divider key={arrival.STATION}>
           <Chip classes={{ root: className }} avatar={<Avatar className='Badge'>{arrival.DIRECTION}</Avatar>} label={arrival.STATION.replace(/ station$/i, '')} />
-          <ListItemText primary={arrival.WAITING_TIME} />
+          <Box mx={2}><ListItemText primary={arrival.WAITING_TIME} /></Box>
         </ListItem>
       );
     }

--- a/src/TrainView/TrainView.js
+++ b/src/TrainView/TrainView.js
@@ -49,7 +49,7 @@ class StationView extends Component {
         <AppBar position="static" color="primary" elevation={0}>
           <Toolbar>
             <IconButton onClick={this.goBack} color="default"><Icon style={{color: 'white'}}>arrow_back</Icon></IconButton>
-            <Typography variant="title" color="inherit">
+            <Typography variant="h6" color="inherit">
               Train ID {this.state.trainID}
             </Typography>
           </Toolbar>
@@ -72,7 +72,7 @@ class StationView extends Component {
       var arrival = this.state.arrivals[i];
       var className = arrival.LINE + "Line";
       res.push(
-        <ListItem divider key={arrival.STATION}>
+        <ListItem button divider key={arrival.STATION}>
           <Chip classes={{ root: className }} avatar={<Avatar className='Badge'>{arrival.DIRECTION}</Avatar>} label={arrival.STATION.replace(/ station$/i, '')} />
           <ListItemText primary={arrival.WAITING_TIME} />
         </ListItem>

--- a/src/theme/theme.jsx
+++ b/src/theme/theme.jsx
@@ -2,6 +2,7 @@ import { grey } from "@material-ui/core/colors";
 
 const AppThemeOptions = {
   light: {
+    spacing: 4,
     palette: {
       type: 'light',
       primary: {
@@ -10,6 +11,7 @@ const AppThemeOptions = {
     },
   },
   dark: {
+    spacing: 4,
     palette: {
       type: 'dark',
       primary: {


### PR DESCRIPTION
- big update here, more work to do
- demoing the [`styled(Component)`](https://material-ui.com/styles/basics/) pattern here for the recommended styling pathway moving forward (if we like it... alternate path is doing this update without any of the style-related motivations)
- put this on https://beta.marta.io so you can look at the current ugliness:

![image](https://user-images.githubusercontent.com/137793/66793064-ad9b8b00-eec9-11e9-9590-ed2d0e65ff69.png)
