### PR TITLE
clean up material ui update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,13 +67,6 @@
         margin-bottom: 5px;
       }
 
-      .Pill span {
-        font-weight: 700;
-        font-size: 1rem;
-        padding-left: 6px;
-        box-sizing: content-box;
-      }
-
       .Pill span.material-icons {
         font-size: 1.1rem;
       }
@@ -84,24 +77,31 @@
         top: -2px;
       }
 
+      .ContainerStationPills :not(.BlankChip) .MuiChip-label {
+        font-family: monospace;
+        font-weight: 700;
+        font-size: 1.3rem;
+      }
+
+      .Badge.MuiChip-avatar {
+        color: #fff;
+        font-size: 1.1rem;
+      }
+
       .GOLDLine .Badge {
         background-color: #ffa700;
-        color: #fff
       }
 
       .REDLine .Badge {
         background-color: #ff5100;
-        color: #fff
       }
 
       .GREENLine .Badge {
         background-color: green;
-        color: #fff
       }
 
       .BLUELine .Badge {
         background-color: #30a7fa;
-        color: #fff
       }
 
       #update-notify .update-notify {

--- a/src/StationListItem/StationListItem.js
+++ b/src/StationListItem/StationListItem.js
@@ -4,6 +4,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import StationPills from '../StationPills/StationPills';
 import Stations from '../marta/stations';
+import Box from '@material-ui/core/Box'
 
 class StationListItem {
   static render(stationName, arrivalData) {
@@ -13,7 +14,7 @@ class StationListItem {
     return (
       <ListItem divider button key={stationName} component={Link} to={link}>
         <ListItemText className="station-list-title" primary={stationName.replace(/ station$/i, '')} />
-        <div className="ContainerStationPills">{this.renderPills(arrivals)}</div>
+        <Box className="ContainerStationPills">{this.renderPills(arrivals)}</Box>
       </ListItem>
     );
   }

--- a/src/StationPills/StationPills.js
+++ b/src/StationPills/StationPills.js
@@ -1,14 +1,9 @@
 import React, { Component } from 'react';
-import { styled } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import Avatar from '@material-ui/core/Avatar';
 import Icon from '@material-ui/core/Icon';
 
 const BLANK_CHIP = <Chip className="BlankChip" style={{opacity: 0.5}} label="NO DATA" />;
-
-const MyChip = styled(Chip)({
-  fontFamily: 'monospace'
-});
 
 class StationPills extends Component {
   static blankPills() {
@@ -41,7 +36,7 @@ class StationPills extends Component {
 
   render() {
     var className = this.props.line + 'Line Pill';
-    return <MyChip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
+    return <Chip classes={{root: className}} avatar={<Avatar className='Badge'>{this.props.dir}</Avatar>} label={this.timeDisplay()} />;
   }
 }
 

--- a/src/StationView/StationView.js
+++ b/src/StationView/StationView.js
@@ -12,6 +12,7 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import Box from '@material-ui/core/Box';
 
 class StationView extends Component {
   constructor(props) {
@@ -88,7 +89,7 @@ class StationView extends Component {
       res.push(
         <ListItem button divider key={arrival.TRAIN_ID} component={Link} to={"/train/" + arrival.TRAIN_ID}>
           <Chip classes={{ root: className }} avatar={<Avatar className="Badge">{arrival.DIRECTION}</Avatar>} label={arrival.DESTINATION} />
-          <ListItemText primary={arrival.WAITING_TIME} />
+          <Box mx={2}><ListItemText primary={arrival.WAITING_TIME} /></Box>
         </ListItem>
       );
     }

--- a/src/TrainView/TrainView.js
+++ b/src/TrainView/TrainView.js
@@ -10,6 +10,7 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import Box from '@material-ui/core/Box';
 
 class StationView extends Component {
   constructor(props) {
@@ -74,7 +75,7 @@ class StationView extends Component {
       res.push(
         <ListItem button divider key={arrival.STATION}>
           <Chip classes={{ root: className }} avatar={<Avatar className='Badge'>{arrival.DIRECTION}</Avatar>} label={arrival.STATION.replace(/ station$/i, '')} />
-          <ListItemText primary={arrival.WAITING_TIME} />
+          <Box mx={2}><ListItemText primary={arrival.WAITING_TIME} /></Box>
         </ListItem>
       );
     }

--- a/src/theme/theme.jsx
+++ b/src/theme/theme.jsx
@@ -2,6 +2,7 @@ import { grey } from "@material-ui/core/colors";
 
 const AppThemeOptions = {
   light: {
+    spacing: 4,
     palette: {
       type: 'light',
       primary: {
@@ -10,6 +11,7 @@ const AppThemeOptions = {
     },
   },
   dark: {
+    spacing: 4,
     palette: {
       type: 'dark',
       primary: {


### PR DESCRIPTION
I dig the styled components but I couldn't get it to fully work the way I wanted for the `TimerChip`. The styles were applied to the root of the chip, and didn't target the label specifically enough. In the full version of styled components, you can do that but not in the Material UI wrapper. Anyway, I gave up on it (for this one implementation) and just used plain ole CSS. 

![image](https://user-images.githubusercontent.com/5190305/69482804-dcbcea80-0ded-11ea-97f1-6af64c992979.png)

![image](https://user-images.githubusercontent.com/5190305/69482810-e9d9d980-0ded-11ea-9300-842edeb1708d.png)

![image](https://user-images.githubusercontent.com/5190305/69482815-f2caab00-0ded-11ea-8aea-432a7e2e9e56.png)

![image](https://user-images.githubusercontent.com/5190305/69482829-273e6700-0dee-11ea-8c76-e8e3f97ed09d.png)

![image](https://user-images.githubusercontent.com/5190305/69482831-2f96a200-0dee-11ea-9a0f-214f5f3dcbd8.png)

![image](https://user-images.githubusercontent.com/5190305/69482835-36bdb000-0dee-11ea-89b4-65903ad7d68d.png)
